### PR TITLE
fix command name and title

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -38,7 +38,7 @@ function report() {
 
 module.exports = function() {
     return this
-        .title('BEM Tool Find')
+        .title('BEM Tool for removing BEM entity files')
         .helpful()
         .completable()
         .arg()

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Tool for removing bem-entities",
   "bin": {
-    "rm": "bin/rm"
+    "bem-rm": "bin/rm"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Переопределяет системную команду **rm**:

```
$ npm i -g bem-incubator/bem-tools-rm
$ which rm
/home/ilyar/.nvm/versions/node/v0.12.9/bin/rm
$ bem
...
Commands:
  rm : BEM Tool Find
...
```

Исправление это решает:

```
$ npm i -g ilyar/bem-tools-rm
$ which rm
/bin/rm
$ bem
....
Commands:
  rm : BEM Tool for removing BEM entity files
...
```
